### PR TITLE
Optimize code

### DIFF
--- a/EDF_Tools/CANM.h
+++ b/EDF_Tools/CANM.h
@@ -37,15 +37,15 @@ struct CANMAnmData
 class CANM
 {
 public:
-	void Read(std::wstring path);
-	void ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header);
+	void Read(const std::wstring& path);
+	void ReadData(const std::vector<char>& buffer, tinyxml2::XMLElement* header);
 	// old
-	void ReadAnimationPointData(tinyxml2::XMLElement* header, std::vector<char> buffer);
+	void ReadAnimationPointData(tinyxml2::XMLElement* header, const std::vector<char>& buffer);
 	// now
-	void ReadAnimationData(tinyxml2::XMLElement* header, std::vector<char> buffer);
+	void ReadAnimationData(tinyxml2::XMLElement* header, const std::vector<char>& buffer);
 	void ReadAnimationDataWriteKeyFrame(tinyxml2::XMLElement* node, int num);
-	void ReadBoneListData(tinyxml2::XMLElement* header, std::vector<char> buffer);
-	CANMAnmKey ReadAnimationFrameData(std::vector<char> buffer, int pos);
+	void ReadBoneListData(tinyxml2::XMLElement* header, const std::vector<char>& buffer);
+	CANMAnmKey ReadAnimationFrameData(const std::vector<char>& buffer, int pos);
 	// faster with the pointer version
 	CANMAnmKey ReadAnimationFrameData(std::vector<char> *buf, int pos, int mask);
 

--- a/EDF_Tools/CAS.cpp
+++ b/EDF_Tools/CAS.cpp
@@ -12,7 +12,7 @@
 #include "CAS.h"
 #include "include/tinyxml2.h"
 
-void CAS::Read(std::wstring path)
+void CAS::Read(const std::wstring& path)
 {
 	std::ifstream file(path + L".cas", std::ios::binary | std::ios::ate | std::ios::in);
 
@@ -23,7 +23,7 @@ void CAS::Read(std::wstring path)
 	if (file.read(buffer.data(), size))
 	{
 		// create xml
-		tinyxml2::XMLDocument xml = new tinyxml2::XMLDocument();
+		tinyxml2::XMLDocument xml;
 		xml.InsertFirstChild(xml.NewDeclaration());
 		tinyxml2::XMLElement* xmlHeader = xml.NewElement("CAS");
 		xml.InsertEndChild(xmlHeader);
@@ -46,7 +46,7 @@ void CAS::Read(std::wstring path)
 	file.close();
 }
 
-void CAS::ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header)
+void CAS::ReadData(const std::vector<char>& buffer, tinyxml2::XMLElement* header)
 {
 	int position = 0;
 	unsigned char seg[4];
@@ -87,11 +87,8 @@ void CAS::ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header)
 
 	// output CANM Data
 	tinyxml2::XMLElement* xmlcanm = header->InsertNewChildElement("CanmData");
-	std::vector<char> newbuf;
 	// no data size, so copy remain
-	int filesize = buffer.size() - CANM_Offset;
-	for (int i = 0; i < filesize; i++)
-		newbuf.push_back(buffer[CANM_Offset + i]);
+	std::vector<char> newbuf(buffer.begin() + CANM_Offset, buffer.end());
 	
 	std::unique_ptr< CANM > CANMReader = std::make_unique< CANM >();
 	CANMReader->ReadData(newbuf, xmlcanm);
@@ -122,7 +119,7 @@ void CAS::ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header)
 		ReadAnmGroupNodeDataPtrCommon(buffer, xmlunk, i_UnkCOffset);
 }
 
-void CAS::ReadCANMName(tinyxml2::XMLElement* header, std::vector<char> buffer)
+void CAS::ReadCANMName(tinyxml2::XMLElement* header, const std::vector<char>& buffer)
 {
 	int nameCount, nameOffset;
 	memcpy(&nameCount, &buffer[0x8], 4U);
@@ -139,7 +136,7 @@ void CAS::ReadCANMName(tinyxml2::XMLElement* header, std::vector<char> buffer)
 	}
 }
 
-void CAS::ReadTControlData(tinyxml2::XMLElement* header, std::vector<char> buffer)
+void CAS::ReadTControlData(tinyxml2::XMLElement* header, const std::vector<char>& buffer)
 {
 	tinyxml2::XMLElement* xmlTCD = header->InsertNewChildElement("TControl");
 	for (int i = 0; i < i_TControlCount; i++)
@@ -186,7 +183,7 @@ void CAS::ReadTControlData(tinyxml2::XMLElement* header, std::vector<char> buffe
 	// end
 }
 
-void CAS::ReadVControlData(tinyxml2::XMLElement* header, std::vector<char> buffer)
+void CAS::ReadVControlData(tinyxml2::XMLElement* header, const std::vector<char>& buffer)
 {
 	tinyxml2::XMLElement* xmlun = header->InsertNewChildElement("VControl");
 	for (int i = 0; i < i_VControlCount; i++)
@@ -225,7 +222,7 @@ void CAS::ReadVControlData(tinyxml2::XMLElement* header, std::vector<char> buffe
 	}
 }
 
-void CAS::ReadAnmGroupData(tinyxml2::XMLElement* header, std::vector<char> buffer)
+void CAS::ReadAnmGroupData(tinyxml2::XMLElement* header, const std::vector<char>& buffer)
 {
 	tinyxml2::XMLElement* xmlun = header->InsertNewChildElement("AnmGroup");
 	for (int i = 0; i < i_AnmGroupCount; i++)
@@ -259,7 +256,7 @@ void CAS::ReadAnmGroupData(tinyxml2::XMLElement* header, std::vector<char> buffe
 	}
 }
 
-void CAS::ReadAnmGroupNodeData(std::vector<char> buffer, int ptrpos, tinyxml2::XMLElement* xmlptr, int index)
+void CAS::ReadAnmGroupNodeData(const std::vector<char>& buffer, int ptrpos, tinyxml2::XMLElement* xmlptr, int index)
 {
 	int ptrvalue[9];
 	memcpy(&ptrvalue, &buffer[ptrpos], 36U);
@@ -323,7 +320,7 @@ void CAS::ReadAnmGroupNodeData(std::vector<char> buffer, int ptrpos, tinyxml2::X
 	}
 }
 
-void CAS::ReadAnmGroupNodeDataPtr(std::vector<char> buffer, tinyxml2::XMLElement* xmldata, int pos)
+void CAS::ReadAnmGroupNodeDataPtr(const std::vector<char>& buffer, tinyxml2::XMLElement* xmldata, int pos)
 {
 	int value[8];
 	memcpy(&value, &buffer[pos], 32U);
@@ -352,7 +349,7 @@ void CAS::ReadAnmGroupNodeDataPtr(std::vector<char> buffer, tinyxml2::XMLElement
 		ReadAnmGroupNodeDataPtrCommon(buffer, xmlptr1, pos + value[2]);
 }
 
-void CAS::ReadAnmGroupNodeDataPtrB(std::vector<char> buffer, tinyxml2::XMLElement* xmldata, int pos)
+void CAS::ReadAnmGroupNodeDataPtrB(const std::vector<char>& buffer, tinyxml2::XMLElement* xmldata, int pos)
 {
 	// not using it now
 	/*
@@ -384,7 +381,7 @@ void CAS::ReadAnmGroupNodeDataPtrB(std::vector<char> buffer, tinyxml2::XMLElemen
 #endif
 }
 
-void CAS::ReadAnmGroupNodeDataPtrCommon(std::vector<char> buffer, tinyxml2::XMLElement* xmldata, int pos)
+void CAS::ReadAnmGroupNodeDataPtrCommon(const std::vector<char>& buffer, tinyxml2::XMLElement* xmldata, int pos)
 {
 	int value[2];
 	memcpy(&value, &buffer[pos], 8U);
@@ -400,7 +397,7 @@ void CAS::ReadAnmGroupNodeDataPtrCommon(std::vector<char> buffer, tinyxml2::XMLE
 	}
 }
 
-void CAS::ReadAnmGroupNodeDataCommon(std::vector<char> buffer, tinyxml2::XMLElement* xmldata, int pos)
+void CAS::ReadAnmGroupNodeDataCommon(const std::vector<char>& buffer, tinyxml2::XMLElement* xmldata, int pos)
 {
 	std::vector< int > value(i_CasDCCount);
 	memcpy(&value[0], &buffer[pos], i_CasDCCount * 4);
@@ -431,7 +428,7 @@ void CAS::ReadAnmGroupNodeDataCommon(std::vector<char> buffer, tinyxml2::XMLElem
 	}
 }
 
-void CAS::ReadBoneListData(tinyxml2::XMLElement* header, std::vector<char> buffer)
+void CAS::ReadBoneListData(tinyxml2::XMLElement* header, const std::vector<char>& buffer)
 {
 	tinyxml2::XMLElement* xmlbone = header->InsertNewChildElement("BoneList");
 	for (int i = 0; i < i_BoneCount; i++)
@@ -478,10 +475,7 @@ void CAS::Write(const std::wstring& path)
 	/**/
 	std::ofstream newFile(path + L".cas", std::ios::binary | std::ios::out | std::ios::ate);
 
-	for (size_t i = 0; i < bytes.size(); i++)
-	{
-		newFile << bytes[i];
-	}
+	newFile.write(bytes.data(), bytes.size());
 
 	newFile.close();
 	
@@ -597,12 +591,10 @@ std::vector<char> CAS::WriteData(tinyxml2::XMLElement* Data)
 	{
 		// need to save this location
 		v_TControl[i].pos = bytes.size();
-		for (size_t j = 0; j < v_TControl[i].bytes.size(); j++)
-			bytes.push_back(v_TControl[i].bytes[j]);
+		bytes.insert(bytes.end(), v_TControl[i].bytes.begin(), v_TControl[i].bytes.end());
 	}
 	// write number data
-	for (size_t i = 0; i < aibytes.size(); i++)
-		bytes.push_back(aibytes[i]);
+	bytes.insert(bytes.end(), aibytes.begin(), aibytes.end());
 	memcpy(&bytes[0x0C], &i_TControlCount, 4U);
 	memcpy(&bytes[0x10], &i_TControlOffset, 4U);
 
@@ -612,22 +604,19 @@ std::vector<char> CAS::WriteData(tinyxml2::XMLElement* Data)
 	{
 		// need to save this location
 		v_VControl[i].pos = bytes.size();
-		for (size_t j = 0; j < v_VControl[i].bytes.size(); j++)
-			bytes.push_back(v_VControl[i].bytes[j]);
+		bytes.insert(bytes.end(), v_VControl[i].bytes.begin(), v_VControl[i].bytes.end());
 	}
 	memcpy(&bytes[0x14], &i_VControlCount, 4U);
 	memcpy(&bytes[0x18], &i_VControlOffset, 4U);
 
 	// write bone list data (all 0)
 	i_BoneOffset = bytes.size();
-	for (size_t i = 0; i < blbytes.size(); i++)
-		bytes.push_back(blbytes[i]);
+	bytes.insert(bytes.end(), blbytes.begin(), blbytes.end());
 	memcpy(&bytes[0x24], &i_BoneCount, 4U);
 	memcpy(&bytes[0x28], &i_BoneOffset, 4U);
 	// write unknown data
 	i_UnkCOffset = bytes.size();
-	for (size_t i = 0; i < unkbytes.size(); i++)
-		bytes.push_back(unkbytes[i]);
+	bytes.insert(bytes.end(), unkbytes.begin(), unkbytes.end());
 	memcpy(&bytes[0x2C], &i_UnkCOffset, 4U);
 
 	// write animation group data
@@ -636,8 +625,7 @@ std::vector<char> CAS::WriteData(tinyxml2::XMLElement* Data)
 	{
 		// need to save this location
 		v_AnmGroup[i].pos = bytes.size();
-		for (size_t j = 0; j < v_AnmGroup[i].bytes.size(); j++)
-			bytes.push_back(v_AnmGroup[i].bytes[j]);
+		bytes.insert(bytes.end(), v_AnmGroup[i].bytes.begin(), v_AnmGroup[i].bytes.end());
 	}
 	memcpy(&bytes[0x1C], &i_AnmGroupCount, 4U);
 	memcpy(&bytes[0x20], &i_AnmGroupOffset, 4U);
@@ -646,12 +634,10 @@ std::vector<char> CAS::WriteData(tinyxml2::XMLElement* Data)
 	{
 		// need to save this location
 		v_AnmSet[i].pos = bytes.size();
-		for (size_t j = 0; j < v_AnmSet[i].bytes.size(); j++)
-			bytes.push_back(v_AnmSet[i].bytes[j]);
+		bytes.insert(bytes.end(), v_AnmSet[i].bytes.begin(), v_AnmSet[i].bytes.end());
 	}
 	// write animation other data
-	for (size_t i = 0; i < v_AnmSetData.size(); i++)
-		bytes.push_back(v_AnmSetData[i]);
+	bytes.insert(bytes.end(), v_AnmSetData.begin(), v_AnmSetData.end());
 
 	// 16-byte alignment is required
 	int i_Alignment = bytes.size() % 16;
@@ -662,8 +648,7 @@ std::vector<char> CAS::WriteData(tinyxml2::XMLElement* Data)
 	}
 	// write canm data
 	CANM_Offset = bytes.size();
-	for (size_t i = 0; i < canmbytes.size(); i++)
-		bytes.push_back(canmbytes[i]);
+	bytes.insert(bytes.end(), canmbytes.begin(), canmbytes.end());
 	memcpy(&bytes[0x8], &CANM_Offset, 4U);
 
 	// write TControl string
@@ -803,8 +788,7 @@ std::vector<char> CAS::WriteUnknownData(tinyxml2::XMLElement* data)
 			std::vector<char> buffer = WriteCASSpecialData(entry, i_CasDCCount);
 			count++;
 
-			for (size_t i = 0; i < buffer.size(); i++)
-				out.push_back(buffer[i]);
+			out.insert(out.end(), buffer.begin(), buffer.end());
 		}
 	}
 	memcpy(&out[0], &count, 4U);
@@ -915,8 +899,7 @@ CASAnmGroup CAS::WriteAnimationSetData(tinyxml2::XMLElement* data, int subnum)
 		memcpy(&out.bytes[4], &value, 4U);
 
 		std::vector<char> buffer = WriteMainAnimationDataA(entry);
-		for (size_t i = 0; i < buffer.size(); i++)
-			v_AnmSetData.push_back(buffer[i]);
+		v_AnmSetData.insert(v_AnmSetData.end(), buffer.begin(), buffer.end());
 	}
 	// read data2
 	entry = data->FirstChildElement("data2");
@@ -934,8 +917,7 @@ CASAnmGroup CAS::WriteAnimationSetData(tinyxml2::XMLElement* data, int subnum)
 			dataPos.push_back(v_AnmSetData.size());
 			// read data
 			std::vector<char> buffer = WriteMainAnimationDataB(entry2);
-			for (size_t i = 0; i < buffer.size(); i++)
-				v_AnmSetData.push_back(buffer[i]);
+			v_AnmSetData.insert(v_AnmSetData.end(), buffer.begin(), buffer.end());
 		}
 		memcpy(&out.bytes[0x8], &value, 4U);
 		// reset value
@@ -951,8 +933,7 @@ CASAnmGroup CAS::WriteAnimationSetData(tinyxml2::XMLElement* data, int subnum)
 				memcpy(&v_AnmSetData[curpos + 8], &offset, 4U);
 				// read parameter data
 				std::vector<char> buffer = WriteUnknownData(entry3);
-				for (size_t i = 0; i < buffer.size(); i++)
-					v_AnmSetData.push_back(buffer[i]);
+				v_AnmSetData.insert(v_AnmSetData.end(), buffer.begin(), buffer.end());
 			}
 			// finally add "value"
 			value++;
@@ -966,8 +947,7 @@ CASAnmGroup CAS::WriteAnimationSetData(tinyxml2::XMLElement* data, int subnum)
 		memcpy(&out.bytes[0x10], &value, 4U);
 
 		std::vector<char> buffer = WriteUnknownData(entry);
-		for (size_t i = 0; i < buffer.size(); i++)
-			v_AnmSetData.push_back(buffer[i]);
+		v_AnmSetData.insert(v_AnmSetData.end(), buffer.begin(), buffer.end());
 	}
 	// read parametric2
 	entry = data->FirstChildElement("parametric2");
@@ -977,8 +957,7 @@ CASAnmGroup CAS::WriteAnimationSetData(tinyxml2::XMLElement* data, int subnum)
 		memcpy(&out.bytes[0x14], &value, 4U);
 
 		std::vector<char> buffer = WriteUnknownData(entry);
-		for (size_t i = 0; i < buffer.size(); i++)
-			v_AnmSetData.push_back(buffer[i]);
+		v_AnmSetData.insert(v_AnmSetData.end(), buffer.begin(), buffer.end());
 	}
 	// read parametric3
 	entry = data->FirstChildElement("parametric3");
@@ -988,8 +967,7 @@ CASAnmGroup CAS::WriteAnimationSetData(tinyxml2::XMLElement* data, int subnum)
 		memcpy(&out.bytes[0x18], &value, 4U);
 
 		std::vector<char> buffer = WriteUnknownData(entry);
-		for (size_t i = 0; i < buffer.size(); i++)
-			v_AnmSetData.push_back(buffer[i]);
+		v_AnmSetData.insert(v_AnmSetData.end(), buffer.begin(), buffer.end());
 	}
 
 	return out;
@@ -1036,8 +1014,7 @@ std::vector<char> CAS::WriteMainAnimationDataA(tinyxml2::XMLElement* data)
 		memcpy(&out[0x8], &value, 4U);
 
 		std::vector<char> buffer = WriteUnknownData(entry);
-		for (size_t i = 0; i < buffer.size(); i++)
-			out.push_back(buffer[i]);
+		out.insert(out.end(), buffer.begin(), buffer.end());
 	}
 
 	return out;

--- a/EDF_Tools/CAS.h
+++ b/EDF_Tools/CAS.h
@@ -27,19 +27,19 @@ struct CASAnmGroup
 class CAS
 {
 public:
-	void Read(std::wstring path);
-	void ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header);
+	void Read(const std::wstring& path);
+	void ReadData(const std::vector<char>& buffer, tinyxml2::XMLElement* header);
 
-	void ReadCANMName(tinyxml2::XMLElement* header, std::vector<char> buffer);
-	void ReadTControlData(tinyxml2::XMLElement* header, std::vector<char> buffer);
-	void ReadVControlData(tinyxml2::XMLElement* header, std::vector<char> buffer);
-	void ReadAnmGroupData(tinyxml2::XMLElement* header, std::vector<char> buffer);
-	void ReadAnmGroupNodeData(std::vector<char> buffer, int ptrpos, tinyxml2::XMLElement* xmlptr, int index);
-	void ReadAnmGroupNodeDataPtr(std::vector<char> buffer, tinyxml2::XMLElement* xmldata, int pos);
-	void ReadAnmGroupNodeDataPtrB(std::vector<char> buffer, tinyxml2::XMLElement* xmldata, int pos);
-	void ReadAnmGroupNodeDataPtrCommon(std::vector<char> buffer, tinyxml2::XMLElement* xmldata, int pos);
-	void ReadAnmGroupNodeDataCommon(std::vector<char> buffer, tinyxml2::XMLElement* xmldata, int pos);
-	void ReadBoneListData(tinyxml2::XMLElement* header, std::vector<char> buffer);
+	void ReadCANMName(tinyxml2::XMLElement* header, const std::vector<char>& buffer);
+	void ReadTControlData(tinyxml2::XMLElement* header, const std::vector<char>& buffer);
+	void ReadVControlData(tinyxml2::XMLElement* header, const std::vector<char>& buffer);
+	void ReadAnmGroupData(tinyxml2::XMLElement* header, const std::vector<char>& buffer);
+	void ReadAnmGroupNodeData(const std::vector<char>& buffer, int ptrpos, tinyxml2::XMLElement* xmlptr, int index);
+	void ReadAnmGroupNodeDataPtr(const std::vector<char>& buffer, tinyxml2::XMLElement* xmldata, int pos);
+	void ReadAnmGroupNodeDataPtrB(const std::vector<char>& buffer, tinyxml2::XMLElement* xmldata, int pos);
+	void ReadAnmGroupNodeDataPtrCommon(const std::vector<char>& buffer, tinyxml2::XMLElement* xmldata, int pos);
+	void ReadAnmGroupNodeDataCommon(const std::vector<char>& buffer, tinyxml2::XMLElement* xmldata, int pos);
+	void ReadBoneListData(tinyxml2::XMLElement* header, const std::vector<char>& buffer);
 	// to cas
 	void Write(const std::wstring& path);
 	std::vector< char > WriteData(tinyxml2::XMLElement* Data);

--- a/EDF_Tools/EDF_Tools.cpp
+++ b/EDF_Tools/EDF_Tools.cpp
@@ -72,7 +72,7 @@ void ProcessFile( const std::wstring& path, int extraFlags )
     using namespace std;
 
 	//Get file extension:
-	size_t lastindex = path.find_last_of( L"." );
+	size_t lastindex = path.find_last_of( L'.' );
 
 	if( lastindex != wstring::npos )
 	{ 
@@ -207,7 +207,7 @@ void ProcessFile( const std::wstring& path, int extraFlags )
 		}
 		else if (extension == L"xml")
 		{
-			size_t xmlIndex = strn.find_last_of(L"_");
+			size_t xmlIndex = strn.find_last_of(L'_');
 			wstring xmlExtension = strn.substr(xmlIndex + 1, xmlExtension.size() - xmlIndex);
 			wstring xmlStrn = strn.substr(0, xmlIndex);
 
@@ -571,10 +571,7 @@ int _tmain( int argc, wchar_t* argv[] )
 			std::vector< char > comprFile = compressor.Decompress( );
 
 			std::ofstream file = std::ofstream( L"decompressed_" + path, std::ios::binary | std::ios::out | std::ios::ate );
-			for( int i = 0; i < comprFile.size(); ++i )
-			{
-				file << comprFile[i];
-			}
+			file.write(comprFile.data(), comprFile.size());
 			file.close( );
 
 			comprFile.clear( );

--- a/EDF_Tools/JSONAMLParser.cpp
+++ b/EDF_Tools/JSONAMLParser.cpp
@@ -97,7 +97,7 @@ JSONAMLNode::JSONAMLNode( std::wstring node )
 	}
 }
 
-std::wstring JSONAMLNode::GetValue( std::wstring key )
+std::wstring JSONAMLNode::GetValue( const std::wstring& key )
 {
 	if( DetermineType( values[key]->val ) == T_STRING )
 	{
@@ -109,7 +109,7 @@ std::wstring JSONAMLNode::GetValue( std::wstring key )
 	return values[key]->val;
 }
 
-CJSONAMLParser::CJSONAMLParser( std::wstring filePath )
+CJSONAMLParser::CJSONAMLParser( const std::wstring& filePath )
 {
 	std::wstring rawString = L"root:" + ReadFile( filePath.c_str() );
 
@@ -120,12 +120,12 @@ CJSONAMLParser::CJSONAMLParser( std::wstring filePath )
 	root = std::make_unique< JSONAMLNode >( proccess );
 }
 
-JSONAMLValueArr * CJSONAMLParser::GetValueAsArrNode( JSONAMLNode * node, std::wstring value )
+JSONAMLValueArr * CJSONAMLParser::GetValueAsArrNode( JSONAMLNode * node, const std::wstring& value )
 {
 	return (JSONAMLValueArr *)( node->values[value].get( ) );
 }
 
-JSONAMLNode * CJSONAMLParser::FindNode( std::wstring key, std::wstring value, bool caseSensitive, JSONAMLNode * iroot )
+JSONAMLNode * CJSONAMLParser::FindNode( const std::wstring& key, const std::wstring& value, bool caseSensitive, JSONAMLNode * iroot )
 {
 	if( iroot == NULL )
 	{
@@ -235,7 +235,7 @@ JSONAMLValueArr::JSONAMLValueArr( std::wstring parseStrn )
 	}
 }
 
-JSONAMLNode * JSONAMLValueArr::LoopUpNode( std::wstring key, std::wstring value, bool caseSensitive )
+JSONAMLNode * JSONAMLValueArr::LoopUpNode( const std::wstring& key, const std::wstring& value, bool caseSensitive )
 {
 	for( int i = 0; i < nodes.size( ); ++i )
 	{

--- a/EDF_Tools/JSONAMLParser.h
+++ b/EDF_Tools/JSONAMLParser.h
@@ -21,7 +21,7 @@ struct JSONAMLValue
 struct JSONAMLNode
 {
 	JSONAMLNode( std::wstring nodeText );
-	std::wstring GetValue( std::wstring key );
+	std::wstring GetValue( const std::wstring& key );
 
 	std::map< std::wstring, std::unique_ptr<JSONAMLValue> > values;
 };
@@ -30,7 +30,7 @@ struct JSONAMLValueArr : public JSONAMLValue
 {
 	JSONAMLValueArr( std::wstring parseStrn );
 
-	JSONAMLNode * LoopUpNode( std::wstring key, std::wstring value, bool caseSensitive = false );
+	JSONAMLNode * LoopUpNode( const std::wstring& key, const std::wstring& value, bool caseSensitive = false );
 
 	std::vector< std::unique_ptr<JSONAMLNode> > nodes;
 };
@@ -45,10 +45,10 @@ struct JSONAMLValueSubnode : public JSONAMLValue
 class CJSONAMLParser
 {
 public:
-	CJSONAMLParser( std::wstring filePath );
+	CJSONAMLParser( const std::wstring& filePath );
 
-	JSONAMLValueArr * GetValueAsArrNode( JSONAMLNode * node, std::wstring value );
-	JSONAMLNode * FindNode( std::wstring key, std::wstring value, bool caseSensitive = false, JSONAMLNode *root = NULL );
+	JSONAMLValueArr * GetValueAsArrNode( JSONAMLNode * node, const std::wstring& value );
+	JSONAMLNode * FindNode( const std::wstring& key, const std::wstring& value, bool caseSensitive = false, JSONAMLNode *root = NULL );
 
 	std::wstring SearchTest( );
 

--- a/EDF_Tools/MAB.h
+++ b/EDF_Tools/MAB.h
@@ -30,16 +30,16 @@ struct MABData
 class MAB
 {
 public:
-	void Read(std::wstring path);
-	void ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader);
-	void ReadBoneData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlBone, tinyxml2::XMLElement* xmlHeader);
-	void ReadBoneTypeData(int type, std::vector<char>& buffer, int ptrpos, tinyxml2::XMLElement* xmlBPtr);
+	void Read(const std::wstring& path);
+	void ReadData(const std::vector<char>& buffer, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader);
+	void ReadBoneData(const std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlBone, tinyxml2::XMLElement* xmlHeader);
+	void ReadBoneTypeData(int type, const std::vector<char>& buffer, int ptrpos, tinyxml2::XMLElement* xmlBPtr);
 	void Read4FloatData(tinyxml2::XMLElement* xmlNode, float* vf);
-	void ReadExtraSGO(std::string& namestr, std::vector<char>& buffer, int pos, tinyxml2::XMLElement*& xmlHeader);
-	void ReadAnimeData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlAnm, tinyxml2::XMLElement* xmlHeader);
-	void ReadAnimeDataA(std::vector<char>& buffer, int pos, tinyxml2::XMLElement* xmlNode, tinyxml2::XMLElement* xmlHeader);
+	void ReadExtraSGO(std::string& namestr, const std::vector<char>& buffer, int pos, tinyxml2::XMLElement*& xmlHeader);
+	void ReadAnimeData(const std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlAnm, tinyxml2::XMLElement* xmlHeader);
+	void ReadAnimeDataA(const std::vector<char>& buffer, int pos, tinyxml2::XMLElement* xmlNode, tinyxml2::XMLElement* xmlHeader);
 
-	void Write(std::wstring path, tinyxml2::XMLNode* header);
+	void Write(const std::wstring& path, tinyxml2::XMLNode* header);
 	std::vector< char > WriteData(tinyxml2::XMLElement* mainData, tinyxml2::XMLNode* header);
 	void GetMABString(std::string namestr);
 	void GetMABExtraDataName(tinyxml2::XMLElement* data);
@@ -47,8 +47,8 @@ public:
 
 	MABExtraData GetExtraData(tinyxml2::XMLElement* entry, std::string dataName, tinyxml2::XMLNode* header, int pos);
 
-	int GetMABStringOffset(std::string namestr);
-	int GetMABExtraOffset(std::string namestr);
+	int GetMABStringOffset(const std::string& namestr);
+	int GetMABExtraOffset(const std::string& namestr);
 
 	MABData GetMABBoneData(tinyxml2::XMLElement* entry2, int ptrpos);
 	MABData GetMABBonePtrData(tinyxml2::XMLElement* entry3);

--- a/EDF_Tools/MDB.cpp
+++ b/EDF_Tools/MDB.cpp
@@ -42,7 +42,7 @@ int CMDBtoXML::Read(const std::wstring& path, bool onecore)
 			return -1;
 		}
 
-		tinyxml2::XMLDocument xml = new tinyxml2::XMLDocument();
+		tinyxml2::XMLDocument xml;
 		xml.InsertFirstChild(xml.NewDeclaration());
 		tinyxml2::XMLElement* xmlHeader = xml.NewElement("MDB");
 		xml.InsertEndChild(xmlHeader);
@@ -555,7 +555,7 @@ int CMDBtoXML::Read(const std::wstring& path, bool onecore)
 					std::wstring wstrm = textures[tempint].mapping;
 					std::wstring wstrn = textures[tempint].filename;
 					//check mapping length
-					size_t nnsize = wstrm.find_last_of(L"_") + 4;
+					size_t nnsize = wstrm.find_last_of(L'_') + 4;
 					size_t wmsize = wstrm.size();
 					// Truncate the tail of the mapping as a mipmap
 					std::string mipmap;
@@ -613,7 +613,7 @@ int CMDBtoXML::Read(const std::wstring& path, bool onecore)
 	}
 }
 
-MDBName CMDBtoXML::ReadMDBName(int pos, std::vector<char> buffer)
+MDBName CMDBtoXML::ReadMDBName(int pos, const std::vector<char>& buffer)
 {
 	MDBName out;
 
@@ -631,7 +631,7 @@ MDBName CMDBtoXML::ReadMDBName(int pos, std::vector<char> buffer)
 	return out;
 }
 
-MDBBone CMDBtoXML::ReadBone(int pos, std::vector<char> buffer)
+MDBBone CMDBtoXML::ReadBone(int pos, const std::vector<char>& buffer)
 {
 	MDBBone out;
 
@@ -665,7 +665,7 @@ MDBBone CMDBtoXML::ReadBone(int pos, std::vector<char> buffer)
 	return out;
 }
 
-MDBMaterial CMDBtoXML::ReadMaterial(int pos, std::vector<char> buffer)
+MDBMaterial CMDBtoXML::ReadMaterial(int pos, const std::vector<char>& buffer)
 {
 	MDBMaterial out;
 
@@ -700,7 +700,7 @@ MDBMaterial CMDBtoXML::ReadMaterial(int pos, std::vector<char> buffer)
 	return out;
 }
 
-MDBMaterialPtr CMDBtoXML::ReadMaterialPtr(int pos, std::vector<char> buffer)
+MDBMaterialPtr CMDBtoXML::ReadMaterialPtr(int pos, const std::vector<char>& buffer)
 {
 	MDBMaterialPtr out;
 
@@ -734,7 +734,7 @@ MDBMaterialPtr CMDBtoXML::ReadMaterialPtr(int pos, std::vector<char> buffer)
 	return out;
 }
 
-MDBMaterialTex CMDBtoXML::ReadMaterialTex(int pos, std::vector<char> buffer)
+MDBMaterialTex CMDBtoXML::ReadMaterialTex(int pos, const std::vector<char>& buffer)
 {
 	MDBMaterialTex out;
 
@@ -753,7 +753,7 @@ MDBMaterialTex CMDBtoXML::ReadMaterialTex(int pos, std::vector<char> buffer)
 	return out;
 }
 
-MDBObject CMDBtoXML::ReadObject(int pos, std::vector<char> buffer)
+MDBObject CMDBtoXML::ReadObject(int pos, const std::vector<char>& buffer)
 {
 	MDBObject out;
 
@@ -779,7 +779,7 @@ MDBObject CMDBtoXML::ReadObject(int pos, std::vector<char> buffer)
 	return out;
 }
 
-MDBObjectInfo CMDBtoXML::ReadObjectInfo(int pos, std::vector<char> buffer)
+MDBObjectInfo CMDBtoXML::ReadObjectInfo(int pos, const std::vector<char>& buffer)
 {
 	MDBObjectInfo out;
 
@@ -826,7 +826,7 @@ MDBObjectInfo CMDBtoXML::ReadObjectInfo(int pos, std::vector<char> buffer)
 	return out;
 }
 
-MDBObjectLayout CMDBtoXML::ReadObjectLayout(int pos, std::vector<char> buffer)
+MDBObjectLayout CMDBtoXML::ReadObjectLayout(int pos, const std::vector<char>& buffer)
 {
 	MDBObjectLayout out;
 
@@ -852,7 +852,7 @@ MDBObjectLayout CMDBtoXML::ReadObjectLayout(int pos, std::vector<char> buffer)
 	return out;
 }
 
-MDBTexture CMDBtoXML::ReadTexture(int pos, std::vector<char> buffer)
+MDBTexture CMDBtoXML::ReadTexture(int pos, const std::vector<char>& buffer)
 {
 	MDBTexture out;
 
@@ -879,7 +879,7 @@ MDBTexture CMDBtoXML::ReadTexture(int pos, std::vector<char> buffer)
 	return out;
 }
 
-void CMDBtoXML::ReadVertex(int pos, std::vector<char> buffer, int type, int num, int size, tinyxml2::XMLElement* header)
+void CMDBtoXML::ReadVertex(int pos, const std::vector<char>& buffer, int type, int num, int size, tinyxml2::XMLElement* header)
 {
 	if (type == 1)
 	{
@@ -971,7 +971,7 @@ void CMDBtoXML::ReadVertex(int pos, std::vector<char> buffer, int type, int num,
 	}
 }
 
-void CMDBtoXML::ReadVertexMT(std::mutex& mtx, int pos, std::vector<char> buffer, int type, int num, int size, tinyxml2::XMLElement* header)
+void CMDBtoXML::ReadVertexMT(std::mutex& mtx, int pos, const std::vector<char>& buffer, int type, int num, int size, tinyxml2::XMLElement* header)
 {
 	if (type == 1)
 	{
@@ -1103,8 +1103,6 @@ void CMDBtoXML::ReadVertexMT(std::mutex& mtx, int pos, std::vector<char> buffer,
 		header->SetText(strn.c_str());
 	}
 }
-
-#include <filesystem>
 
 void CXMLToMDB::Write(const std::wstring& path, bool multcore)
 {
@@ -1241,10 +1239,7 @@ void CXMLToMDB::Write(const std::wstring& path, bool multcore)
 	//Push bone list
 	for (size_t i = 0; i < m_vecBone.size(); i++)
 	{
-		for (size_t j = 0; j < m_vecBone[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecBone[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecBone[i].bytes.begin(), m_vecBone[i].bytes.end());
 	}
 
 	//Push texture table count
@@ -1255,10 +1250,7 @@ void CXMLToMDB::Write(const std::wstring& path, bool multcore)
 	for (size_t i = 0; i < m_vecTexture.size(); i++)
 	{
 		m_vecTexPos.push_back(bytes.size());
-		for (size_t j = 0; j < m_vecTexture[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecTexture[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecTexture[i].bytes.begin(), m_vecTexture[i].bytes.end());
 	}
 
 	//Push material list count
@@ -1269,28 +1261,19 @@ void CXMLToMDB::Write(const std::wstring& path, bool multcore)
 	for (size_t i = 0; i < m_vecMaterial.size(); i++)
 	{
 		m_vecMatPos.push_back(bytes.size());
-		for (size_t j = 0; j < m_vecMaterial[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecMaterial[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecMaterial[i].bytes.begin(), m_vecMaterial[i].bytes.end());
 	}
 	//Push material list parameter
 	for (size_t i = 0; i < m_vecMaterialPtr.size(); i++)
 	{
 		m_vecMatPtrPos.push_back(bytes.size());
-		for (size_t j = 0; j < m_vecMaterialPtr[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecMaterialPtr[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecMaterialPtr[i].bytes.begin(), m_vecMaterialPtr[i].bytes.end());
 	}
 	//Push material list texture
 	for (size_t i = 0; i < m_vecMaterialTex.size(); i++)
 	{
 		m_vecMatTexPos.push_back(bytes.size());
-		for (size_t j = 0; j < m_vecMaterialTex[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecMaterialTex[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecMaterialTex[i].bytes.begin(), m_vecMaterialTex[i].bytes.end());
 	}
 	//Actually a material's parameters and texture are together,
 	//Now output parameters and textures separately.
@@ -1313,28 +1296,19 @@ void CXMLToMDB::Write(const std::wstring& path, bool multcore)
 	for (size_t i = 0; i < m_vecObject.size(); i++)
 	{
 		m_vecModelPos.push_back(bytes.size());
-		for (size_t j = 0; j < m_vecObject[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecObject[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecObject[i].bytes.begin(), m_vecObject[i].bytes.end());
 	}
 	//Push model info
 	for (size_t i = 0; i < m_vecObjInfo.size(); i++)
 	{
 		m_vecObjInfoPos.push_back(bytes.size());
-		for (size_t j = 0; j < m_vecObjInfo[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecObjInfo[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecObjInfo[i].bytes.begin(), m_vecObjInfo[i].bytes.end());
 	}
 	//Push model layout
 	for (size_t i = 0; i < m_vecObjLayout.size(); i++)
 	{
 		m_vecObjLayPos.push_back(bytes.size());
-		for (size_t j = 0; j < m_vecObjLayout[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecObjLayout[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecObjLayout[i].bytes.begin(), m_vecObjLayout[i].bytes.end());
 		//Data tails for each model may need to be aligned
 		//AlignFileTo16Bytes(bytes);
 	}
@@ -1343,10 +1317,7 @@ void CXMLToMDB::Write(const std::wstring& path, bool multcore)
 	{
 		// write offset to model info
 		Set4BytesInFile(bytes, (m_vecObjInfoPos[i] + 0x24), (bytes.size() - m_vecObjInfoPos[i]));
-		for (size_t j = 0; j < m_vecObjIndices[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecObjIndices[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecObjIndices[i].bytes.begin(), m_vecObjIndices[i].bytes.end());
 		//AlignFileTo16Bytes(bytes);
 	}
 	//Push model vertices
@@ -1354,10 +1325,7 @@ void CXMLToMDB::Write(const std::wstring& path, bool multcore)
 	{
 		// write offset to model info
 		Set4BytesInFile(bytes, (m_vecObjInfoPos[i] + 0x1C), (bytes.size() - m_vecObjInfoPos[i]));
-		for (size_t j = 0; j < m_vecObjVertices[i].bytes.size(); j++)
-		{
-			bytes.push_back(m_vecObjVertices[i].bytes[j]);
-		}
+		bytes.insert(bytes.end(), m_vecObjVertices[i].bytes.begin(), m_vecObjVertices[i].bytes.end());
 		// The last one does not need to be aligned
 		/*
 		if((i+1) < m_vecObjVertices.size())
@@ -1438,10 +1406,7 @@ void CXMLToMDB::Write(const std::wstring& path, bool multcore)
 	/**/
 	std::ofstream newFile(path + L".mdb", std::ios::binary | std::ios::out | std::ios::ate);
 	
-	for (int i = 0; i < bytes.size(); i++)
-	{
-		newFile << bytes[i];
-	}
+	newFile.write(bytes.data(), bytes.size());
 	
 	newFile.close();
 	
@@ -1799,7 +1764,7 @@ MDBMaterialTex CXMLToMDB::GetMaterialTexture(tinyxml2::XMLElement* entry4, bool 
 	{
 		wstr2 = UTF8ToWide(entry5->GetText());
 		wstr1 = wstr2;
-		wstr1.replace(wstr1.find_last_of(L"."), 1U, L"_");
+		wstr1.replace(wstr1.find_last_of(L'.'), 1U, L"_");
 		if (mipmap != 0)
 		{
 			wstr1 += ToString(mipmap);

--- a/EDF_Tools/MDB.h
+++ b/EDF_Tools/MDB.h
@@ -121,21 +121,21 @@ class CMDBtoXML
 public:
 	int Read(const std::wstring& path, bool onecore);
 
-	MDBName ReadMDBName(int pos, std::vector<char> buffer);
-	MDBTexture ReadTexture(int pos, std::vector<char> buffer);
+	MDBName ReadMDBName(int pos, const std::vector<char>& buffer);
+	MDBTexture ReadTexture(int pos, const std::vector<char>& buffer);
 
-	MDBBone ReadBone(int pos, std::vector<char> buffer);
+	MDBBone ReadBone(int pos, const std::vector<char>& buffer);
 
-	MDBMaterial ReadMaterial(int pos, std::vector<char> buffer);
-	MDBMaterialPtr ReadMaterialPtr(int pos, std::vector<char> buffer);
-	MDBMaterialTex ReadMaterialTex(int pos, std::vector<char> buffer);
+	MDBMaterial ReadMaterial(int pos, const std::vector<char>& buffer);
+	MDBMaterialPtr ReadMaterialPtr(int pos, const std::vector<char>& buffer);
+	MDBMaterialTex ReadMaterialTex(int pos, const std::vector<char>& buffer);
 
-	MDBObject ReadObject(int pos, std::vector<char> buffer);
-	MDBObjectInfo ReadObjectInfo(int pos, std::vector<char> buffer);
-	MDBObjectLayout ReadObjectLayout(int pos, std::vector<char> buffer);
+	MDBObject ReadObject(int pos, const std::vector<char>& buffer);
+	MDBObjectInfo ReadObjectInfo(int pos, const std::vector<char>& buffer);
+	MDBObjectLayout ReadObjectLayout(int pos, const std::vector<char>& buffer);
 
-	void ReadVertex(int pos, std::vector<char> buffer, int type, int num, int size, tinyxml2::XMLElement* header);
-	void ReadVertexMT(std::mutex &mtx, int pos, std::vector<char> buffer, int type, int num, int size, tinyxml2::XMLElement* header);
+	void ReadVertex(int pos, const std::vector<char>& buffer, int type, int num, int size, tinyxml2::XMLElement* header);
+	void ReadVertexMT(std::mutex &mtx, int pos, const std::vector<char>& buffer, int type, int num, int size, tinyxml2::XMLElement* header);
 
 private:
 

--- a/EDF_Tools/MTAB.cpp
+++ b/EDF_Tools/MTAB.cpp
@@ -12,7 +12,7 @@
 #include "MTAB.h"
 #include "include/tinyxml2.h"
 
-void MTAB::Read(std::wstring path)
+void MTAB::Read(const std::wstring& path)
 {
 	std::ifstream file(path + L".mtab", std::ios::binary | std::ios::ate | std::ios::in);
 
@@ -23,7 +23,7 @@ void MTAB::Read(std::wstring path)
 	if (file.read(buffer.data(), size))
 	{
 		// create xml
-		tinyxml2::XMLDocument xml = new tinyxml2::XMLDocument();
+		tinyxml2::XMLDocument xml;
 		xml.InsertFirstChild(xml.NewDeclaration());
 		tinyxml2::XMLElement* xmlHeader = xml.NewElement("EDFDATA");
 		xml.InsertEndChild(xmlHeader);
@@ -49,7 +49,7 @@ void MTAB::Read(std::wstring path)
 	file.close();
 }
 
-void MTAB::ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader)
+void MTAB::ReadData(const std::vector<char>& buffer, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader)
 {
 	int position = 0;
 	unsigned char seg[4];
@@ -83,7 +83,7 @@ void MTAB::ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header, tiny
 	}
 }
 
-void MTAB::ReadMainActionData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader)
+void MTAB::ReadMainActionData(const std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader)
 {
 
 #if defined(DEBUGMODE)
@@ -109,7 +109,7 @@ void MTAB::ReadMainActionData(std::vector<char>& buffer, int curpos, tinyxml2::X
 	}
 }
 
-void MTAB::ReadSubActionData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader)
+void MTAB::ReadSubActionData(const std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader)
 {
 
 #if defined(DEBUGMODE)
@@ -135,7 +135,7 @@ void MTAB::ReadSubActionData(std::vector<char>& buffer, int curpos, tinyxml2::XM
 	}
 }
 
-void MTAB::ReadNodeData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader)
+void MTAB::ReadNodeData(const std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader)
 {
 
 #if defined(DEBUGMODE)
@@ -171,7 +171,7 @@ void MTAB::ReadNodeData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElem
 	}
 }
 
-void MTAB::Write(std::wstring path, tinyxml2::XMLNode* header)
+void MTAB::Write(const std::wstring& path, tinyxml2::XMLNode* header)
 {
 	std::wcout << "Will output MTAB file.\n";
 
@@ -184,10 +184,7 @@ void MTAB::Write(std::wstring path, tinyxml2::XMLNode* header)
 	/**/
 	std::ofstream newFile(path + L".mtab", std::ios::binary | std::ios::out | std::ios::ate);
 
-	for (int i = 0; i < bytes.size(); i++)
-	{
-		newFile << bytes[i];
-	}
+	newFile.write(bytes.data(), bytes.size());
 
 	newFile.close();
 
@@ -232,8 +229,7 @@ std::vector<char> MTAB::WriteData(tinyxml2::XMLElement* mainData, tinyxml2::XMLN
 	for (size_t i = 0; i < v_MainAction.size(); i++)
 	{
 		v_MainAction[i].pos = bytes.size();
-		for (size_t j = 0; j < v_MainAction[i].bytes.size(); j++)
-			bytes.push_back(v_MainAction[i].bytes[j]);
+		bytes.insert(bytes.end(), v_MainAction[i].bytes.begin(), v_MainAction[i].bytes.end());
 	}
 	// write sub action
 	for (size_t i = 0; i < v_SubAction.size(); i++)
@@ -251,8 +247,7 @@ std::vector<char> MTAB::WriteData(tinyxml2::XMLElement* mainData, tinyxml2::XMLN
 		}
 
 		v_SubAction[i].pos = safpos;
-		for (size_t j = 0; j < v_SubAction[i].bytes.size(); j++)
-			bytes.push_back(v_SubAction[i].bytes[j]);
+		bytes.insert(bytes.end(), v_SubAction[i].bytes.begin(), v_SubAction[i].bytes.end());
 	}
 
 	// write data 1
@@ -271,8 +266,7 @@ std::vector<char> MTAB::WriteData(tinyxml2::XMLElement* mainData, tinyxml2::XMLN
 		}
 
 		v_Data[i].pos = d1_pos;
-		for (size_t j = 0; j < v_Data[i].bytes1.size(); j++)
-			bytes.push_back(v_Data[i].bytes1[j]);
+		bytes.insert(bytes.end(), v_Data[i].bytes1.begin(), v_Data[i].bytes1.end());
 	}
 	// 16-byte alignment is required
 	int i_Alignment = bytes.size() % 16;
@@ -290,8 +284,7 @@ std::vector<char> MTAB::WriteData(tinyxml2::XMLElement* mainData, tinyxml2::XMLN
 		int d2_ofs = d2_pos - d1_pos;
 		memcpy(&bytes[d1_pos + 0x10], &d2_ofs, 4U);
 
-		for (size_t j = 0; j < v_Data[i].bytes2.size(); j++)
-			bytes.push_back(v_Data[i].bytes2[j]);
+		bytes.insert(bytes.end(), v_Data[i].bytes2.begin(), v_Data[i].bytes2.end());
 	}
 
 	// write string

--- a/EDF_Tools/MTAB.h
+++ b/EDF_Tools/MTAB.h
@@ -23,14 +23,14 @@ struct MTABMainAction
 class MTAB
 {
 public:
-	void Read(std::wstring path);
-	void ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader);
-	void ReadMainActionData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader);
-	void ReadSubActionData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader);
-	void ReadNodeData(std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader);
+	void Read(const std::wstring& path);
+	void ReadData(const std::vector<char>& buffer, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader);
+	void ReadMainActionData(const std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader);
+	void ReadSubActionData(const std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader);
+	void ReadNodeData(const std::vector<char>& buffer, int curpos, tinyxml2::XMLElement* xmlData, tinyxml2::XMLElement* xmlHeader);
 
 	// write
-	void Write(std::wstring path, tinyxml2::XMLNode* header);
+	void Write(const std::wstring& path, tinyxml2::XMLNode* header);
 	std::vector< char > WriteData(tinyxml2::XMLElement* mainData, tinyxml2::XMLNode* header);
 	MTABMainAction WriteMainAction(tinyxml2::XMLElement* data);
 	MTABMainAction WriteSubAction(tinyxml2::XMLElement* data);

--- a/EDF_Tools/Middleware.cpp
+++ b/EDF_Tools/Middleware.cpp
@@ -13,7 +13,7 @@
 #include "MTAB.h"
 #include "include/tinyxml2.h"
 
-void CheckDataType(std::vector<char>& buffer, tinyxml2::XMLElement*& xmlHeader, std::string str)
+void CheckDataType(const std::vector<char>& buffer, tinyxml2::XMLElement*& xmlHeader, const std::string& str)
 {
 	char header[4];
 	header[0] = buffer[0];
@@ -64,7 +64,7 @@ void CheckDataType(std::vector<char>& buffer, tinyxml2::XMLElement*& xmlHeader, 
 }
 
 // Check the header to determine the output type
-void CheckXMLHeader(std::wstring path)
+void CheckXMLHeader(const std::wstring& path)
 {
 	std::wstring sourcePath = path + L"_data.xml";
 	std::string UTF8Path = WideToUTF8(sourcePath);

--- a/EDF_Tools/Middleware.h
+++ b/EDF_Tools/Middleware.h
@@ -2,9 +2,9 @@
 #include "include/tinyxml2.h"
 
 // Check for the extra file header
-void CheckDataType(std::vector<char>& buffer, tinyxml2::XMLElement*& xmlHeader, std::string str);
+void CheckDataType(const std::vector<char>& buffer, tinyxml2::XMLElement*& xmlHeader, const std::string& str);
 // write
 // Check the header to determine the output type
-void CheckXMLHeader(std::wstring path);
+void CheckXMLHeader(const std::wstring& path);
 // Check for the extra file header when writing
 std::vector< char > CheckDataType(tinyxml2::XMLElement* Data, tinyxml2::XMLNode* header);

--- a/EDF_Tools/MissionScript.cpp
+++ b/EDF_Tools/MissionScript.cpp
@@ -221,7 +221,7 @@ int CMissionScript::Read( const std::wstring& path )
 	return 1;
 }
 
-void CMissionScript::ReadFn( int position, std::vector<char> buffer, int numArgs, int nextFunctionStart )
+void CMissionScript::ReadFn( int position, const std::vector<char>& buffer, int numArgs, int nextFunctionStart )
 {
 	int ofs = 0;
 	int numLocalVars = 0;
@@ -1708,10 +1708,7 @@ void CMissionScript::Write( const std::wstring& path, int flags )
 	//value + 0x56 + m_vecVarNames[i]
 	if (hasInitFn)
 	{
-		for (int i = 0; i < InitBytes.size(); i++)
-		{
-			bytes.push_back(InitBytes[i]);
-		}
+		bytes.insert(bytes.end(), InitBytes.begin(), InitBytes.end());
 	}
 	else
 	{
@@ -1719,16 +1716,10 @@ void CMissionScript::Write( const std::wstring& path, int flags )
 	}
 
 	//Push function bytes
-	for( int i = 0; i < Fnbytes.size( ); i++ )
-	{
-		bytes.push_back( Fnbytes[i] );
-	}
+	bytes.insert(bytes.end(), Fnbytes.begin(), Fnbytes.end());
 
 	//Push function pointers
-	for( int i = 0; i < fnPointerBytes.size( ); i++ )
-	{
-		bytes.push_back( fnPointerBytes[i] );
-	}
+	bytes.insert(bytes.end(), fnPointerBytes.begin(), fnPointerBytes.end());
 
 	//Push strings
 	for( int i = 0; i < m_vecMissionStrns.size( ); i++ ) 
@@ -1797,10 +1788,7 @@ void CMissionScript::Write( const std::wstring& path, int flags )
 	/* The above seems better
 	if (fnArgBytes.size() > 0)
 	{
-		for (int i = 0; i < fnArgBytes.size(); i++)
-		{
-			bytes.push_back(fnArgBytes[i]);
-		}
+		bytes.insert(bytes.end(), fnArgBytes.begin(), fnArgBytes.end());
 	}*/
 
 	////Variable names
@@ -1883,10 +1871,7 @@ void CMissionScript::Write( const std::wstring& path, int flags )
 	free(eofseg);
 	
 	//Final write.
-	for( int i = 0; i < bytes.size(); i++ )
-	{
-		newMission << bytes[i];
-	}
+	newMission.write(bytes.data(), bytes.size());
 
 	newMission.close();
 

--- a/EDF_Tools/MissionScript.h
+++ b/EDF_Tools/MissionScript.h
@@ -104,7 +104,7 @@ public:
 	//Decompiler
 	void LoadLanguage( std::wstring path, int id );
 	int Read( const std::wstring& path );
-	void ReadFn( int position, std::vector<char> buffer, int numArgs, int nextFunctionStart );
+	void ReadFn( int position, const std::vector<char>& buffer, int numArgs, int nextFunctionStart );
 
 	std::vector< int > m_vecFuncOffsets;
 	std::vector< std::wstring > m_vecMissionStrns;

--- a/EDF_Tools/ModManager.cpp
+++ b/EDF_Tools/ModManager.cpp
@@ -126,7 +126,7 @@ bool CWpnListMgr::RunUI( )
 	return success;
 }
 
-void CWpnListMgr::AddButton( std::wstring strn )
+void CWpnListMgr::AddButton( const std::wstring& strn )
 {
 	HWND hwndButton = CreateWindowW(
 		L"BUTTON",  // Predefined class; Unicode assumed 

--- a/EDF_Tools/ModManager.h
+++ b/EDF_Tools/ModManager.h
@@ -10,7 +10,7 @@ public:
 	long __stdcall HandleWindow( HWND window, unsigned int msg, WPARAM wp, LPARAM lp );
 
 protected:
-	void AddButton( std::wstring strn );
+	void AddButton( const std::wstring& strn );
 
 	void LoadFiles( );
 	std::wstring strPathToWeaponList;

--- a/EDF_Tools/RAB.h
+++ b/EDF_Tools/RAB.h
@@ -37,7 +37,7 @@ RABFileList* __fastcall RABWriteMTCompressNext(RABFileList* File, LPCRITICAL_SEC
 
 struct RABFile
 {
-	RABFile::RABFile( std::wstring name, int fID, std::wstring fullPath );
+	RABFile::RABFile( std::wstring name, int fID, const std::wstring& fullPath );
 	//void LoadData( std::string path );
 
 	std::wstring fileName;
@@ -68,14 +68,14 @@ struct CMPLHandler
 struct RAB
 {
 	//Read
-	void Read( std::wstring path, bool isMRAB );
+	void Read( const std::wstring& path, bool isMRAB );
 
 	//Write
-	void CreateFromDirectory( std::wstring path );
+	void CreateFromDirectory( const std::wstring& path );
 
-	void AddFilesInDirectory( std::wstring path );
+	void AddFilesInDirectory( const std::wstring& path );
 	void AddFile( std::wstring filePath );
-	void Write( std::wstring rabName );
+	void Write( const std::wstring& rabName );
 
 	//Tool properties.
 	bool bUseFakeCompression;

--- a/EDF_Tools/RMPA.cpp
+++ b/EDF_Tools/RMPA.cpp
@@ -104,7 +104,7 @@ int CRMPA::Read( const std::wstring& path )
 	}
 }
 
-void CRMPA::ReadRoutes( std::vector<char> buffer )
+void CRMPA::ReadRoutes( const std::vector<char>& buffer )
 {
 	unsigned char seg[4];
 
@@ -159,7 +159,7 @@ void CRMPA::ReadRoutes( std::vector<char> buffer )
 	}
 }
 
-void CRMPA::ReadSpawnpoints( std::vector<char> buffer )
+void CRMPA::ReadSpawnpoints( const std::vector<char>& buffer )
 {
 	unsigned char seg[4];
 
@@ -214,7 +214,7 @@ void CRMPA::ReadSpawnpoints( std::vector<char> buffer )
 	}
 }
 
-RMPASpawnPoint CRMPA::ReadSpawnpoint( int pos, std::vector<char> buffer )
+RMPASpawnPoint CRMPA::ReadSpawnpoint( int pos, const std::vector<char>& buffer )
 {
 	unsigned char seg[] = { 0x0, 0x0, 0x0, 0x0 };
 
@@ -303,7 +303,7 @@ RMPASpawnPoint CRMPA::ReadSpawnpoint( int pos, std::vector<char> buffer )
 	return point;
 }
 
-RMPARoute CRMPA::ReadRoute( int pos, std::vector<char> buffer )
+RMPARoute CRMPA::ReadRoute( int pos, const std::vector<char>& buffer )
 {
 	unsigned char seg[] = { 0x0, 0x0, 0x0, 0x0 };
 

--- a/EDF_Tools/RMPA.h
+++ b/EDF_Tools/RMPA.h
@@ -71,11 +71,11 @@ class CRMPA
 public:
 	int Read( const std::wstring& path );
 
-	void ReadSpawnpoints( std::vector<char> buffer );
-	void ReadRoutes( std::vector<char> buffer );
+	void ReadSpawnpoints( const std::vector<char>& buffer );
+	void ReadRoutes( const std::vector<char>& buffer );
 
-	RMPASpawnPoint ReadSpawnpoint( int pos, std::vector<char> buffer );
-	RMPARoute ReadRoute( int pos, std::vector<char> buffer );
+	RMPASpawnPoint ReadSpawnpoint( int pos, const std::vector<char>& buffer );
+	RMPARoute ReadRoute( int pos, const std::vector<char>& buffer );
 
 private:
 	std::vector< RMPASpawnPoint > spawnPoints;

--- a/EDF_Tools/SGO.h
+++ b/EDF_Tools/SGO.h
@@ -31,14 +31,14 @@ struct SGOExtraData
 class SGO
 {
 public:
-	void Read( std::wstring path );
-	void ReadData(std::vector<char> buffer, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader);
-	void Read4BytesData(bool big_endian, unsigned char* seg, std::vector<char> buffer, int position);
-	void ReadSGOHeader(bool big_endian, std::vector<char> buffer);
-	void ReadSGONode(bool big_endian, std::vector<char> buffer, int nodepos, std::vector<SGONode>& datanode, int i, tinyxml2::XMLElement*& xmlNode, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader);
+	void Read( const std::wstring& path );
+	void ReadData(const std::vector<char>& buffer, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader);
+	void Read4BytesData(bool big_endian, unsigned char* seg, const std::vector<char>& buffer, int position);
+	void ReadSGOHeader(bool big_endian, const std::vector<char>& buffer);
+	void ReadSGONode(bool big_endian, const std::vector<char>& buffer, int nodepos, std::vector<SGONode>& datanode, int i, tinyxml2::XMLElement*& xmlNode, tinyxml2::XMLElement* header, tinyxml2::XMLElement* xmlHeader);
 
 	// Write
-	void Write(std::wstring path, tinyxml2::XMLNode* header);
+	void Write(const std::wstring& path, tinyxml2::XMLNode* header);
 	std::vector< char > WriteData(tinyxml2::XMLElement* mainData, tinyxml2::XMLNode* header);
 	void GetNodeExtraData(tinyxml2::XMLElement* entry, int& nodePtrNum);
 	SGOExtraData GetExtraData(tinyxml2::XMLElement* entry, std::string dataName, tinyxml2::XMLNode* header);

--- a/EDF_Tools/VMState.cpp
+++ b/EDF_Tools/VMState.cpp
@@ -30,7 +30,7 @@ void VMState::printstatics() const
 {
     for (int i = 0; i < static_RAS.size(); ++i)
     {
-        printf("%ls", static_RAS[i].name);
+        printf("%ls", static_RAS[i].name.c_str());
         if (static_RAS[i].initialized)
         {
             printf(" = %d;\n", static_RAS[i].value);

--- a/EDF_Tools/util.cpp
+++ b/EDF_Tools/util.cpp
@@ -9,19 +9,19 @@
 #include "util.h"
 #include "include/half.hpp"
 
-void Read2Bytes( unsigned char *chunk, std::vector<char> buf, int pos )
+void Read2Bytes( unsigned char *chunk, const std::vector<char>& buf, int pos )
 {
 	chunk[0] = buf[ pos + 1];
 	chunk[1] = buf[ pos ];
 }
 
-void Read2BytesReversed( unsigned char *chunk, std::vector<char> buf, int pos )
+void Read2BytesReversed( unsigned char *chunk, const std::vector<char>& buf, int pos )
 {
 	chunk[0] = buf[ pos ];
 	chunk[1] = buf[ pos + 1 ];
 }
 
-void Read4Bytes(unsigned char* chunk, std::vector<char> buf, int pos)
+void Read4Bytes(unsigned char* chunk, const std::vector<char>& buf, int pos)
 {
 	/*if( globals->endianMode )
 	{
@@ -35,7 +35,7 @@ void Read4Bytes(unsigned char* chunk, std::vector<char> buf, int pos)
 	chunk[0] = buf[pos + 3];
 }
 
-void Read4BytesReversed(unsigned char* chunk, std::vector<char> buf, int pos)
+void Read4BytesReversed(unsigned char* chunk, const std::vector<char>& buf, int pos)
 {
 	chunk[0] = buf[pos];
 	chunk[1] = buf[pos + 1];
@@ -44,7 +44,7 @@ void Read4BytesReversed(unsigned char* chunk, std::vector<char> buf, int pos)
 }
 
 //Read specified number of bytes, which should be a multiple of 2
-void ReadNBytesReversed(unsigned char* chunk, std::vector<char> buf, int pos, int num)
+void ReadNBytesReversed(unsigned char* chunk, const std::vector<char>& buf, int pos, int num)
 {
 	for (int i = num - 1; i >= 0; --i)
 	{
@@ -52,7 +52,7 @@ void ReadNBytesReversed(unsigned char* chunk, std::vector<char> buf, int pos, in
 	}
 }
 
-std::string ReadRaw(std::vector<char> buf, int pos, int num)
+std::string ReadRaw(const std::vector<char>& buf, int pos, int num)
 {
 	std::string str="";
 	unsigned char chunk;
@@ -70,7 +70,7 @@ std::string ReadRaw(std::vector<char> buf, int pos, int num)
 }
 
 //wrong reading, do not use.
-short ReadInt16(std::vector<char> buf, int pos, bool swapEndian)
+short ReadInt16(const std::vector<char>& buf, int pos, bool swapEndian)
 {
 	char chunk[2];
 	if (swapEndian)
@@ -94,7 +94,7 @@ short ReadInt16(std::vector<char> buf, int pos, bool swapEndian)
 	return num;
 }
 
-uint16_t ReadUInt16(std::vector<char> buf, int pos, bool swapEndian)
+uint16_t ReadUInt16(const std::vector<char>& buf, int pos, bool swapEndian)
 {
 	char chunk[2];
 	if (swapEndian)
@@ -118,7 +118,7 @@ uint16_t ReadUInt16(std::vector<char> buf, int pos, bool swapEndian)
 	return num;
 }
 
-float ReadHalfFloat(std::vector<char> buf, int pos, bool swapEndian)
+float ReadHalfFloat(const std::vector<char>& buf, int pos, bool swapEndian)
 {
 	char chunk[2];
 	if (swapEndian)
@@ -189,7 +189,7 @@ char* IntToBytes( int i, bool flip )
 	return bytes;
 }
 
-std::wstring ReadUnicode( std::vector<char> chunk, int pos, bool swapEndian )
+std::wstring ReadUnicode( const std::vector<char>& chunk, int pos, bool swapEndian )
 {
 	if( pos > chunk.size( ) )
 		return L"";
@@ -234,7 +234,7 @@ std::wstring ReadUnicode( std::vector<char> chunk, int pos, bool swapEndian )
 	return wstr;
 }
 
-std::string ReadASCII(std::vector<char> chunk, int pos)
+std::string ReadASCII(const std::vector<char>& chunk, int pos)
 {
 	if (pos > chunk.size())
 		return "";
@@ -378,7 +378,7 @@ std::wstring KillSpaceAndDebug(std::wstring in)
 }
 
 //Checks if a string is a valid int
-bool IsValidInt( const std::wstring input )
+bool IsValidInt( const std::wstring& input )
 {
 	int num;
 	bool valid = true;
@@ -395,7 +395,7 @@ bool IsValidInt( const std::wstring input )
 }
 
 //Checks if a string is a valid float
-bool IsValidFloat( const std::wstring input )
+bool IsValidFloat( const std::wstring& input )
 {
 	float num;
 	bool valid = true;
@@ -478,7 +478,7 @@ std::wstring ReadFile( const wchar_t* filename )
 }
 
 ///Replaces all instances in a string
-void FindAndReplaceAll( std::wstring & data, std::wstring toSearch, std::wstring replaceStr )
+void FindAndReplaceAll( std::wstring & data, const std::wstring& toSearch, const std::wstring& replaceStr )
 {
 	// Get the first occurrence
 	size_t pos = data.find( toSearch );
@@ -493,7 +493,7 @@ void FindAndReplaceAll( std::wstring & data, std::wstring toSearch, std::wstring
 	}
 }
 
-void FindAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr)
+void FindAndReplaceAll(std::string& data, const std::string& toSearch, const std::string& replaceStr)
 {
 	// Get the first occurrence
 	size_t pos = data.find(toSearch);
@@ -509,30 +509,23 @@ void FindAndReplaceAll(std::string& data, std::string toSearch, std::string repl
 }
 
 //Function to write a string to a char vector
-void PushStringToVector(std::string strn, std::vector< char >* bytes)
+void PushStringToVector(const std::string& strn, std::vector< char >* bytes)
 {
-	for (int i = 0; i < strn.size(); i++)
-	{
-		bytes->push_back(strn[i]);
-	}
+	bytes->insert(bytes->end(), strn.begin(), strn.end());
 	//Zero terminate
 	bytes->push_back(0x0);
 }
 
 //Function to write a string to a char vector, but no tail
-void PushStringToVectorNoEnd(std::string strn, std::vector< char >* bytes)
+void PushStringToVectorNoEnd(const std::string& strn, std::vector< char >* bytes)
 {
-	for (int i = 0; i < strn.size(); i++)
-	{
-		bytes->push_back(strn[i]);
-	}
+	bytes->insert(bytes->end(), strn.begin(), strn.end());
 }
 
 ///Function to write a wstring to a char vector
-void PushWStringToVector( std::wstring strn, std::vector< char > *bytes )
+void PushWStringToVector( const std::wstring& strn, std::vector< char > *bytes )
 {
-	char* strnBytes;
-	strnBytes = reinterpret_cast<char*>( &strn[0] );
+	const char* strnBytes = reinterpret_cast<const char*>( &strn[0] );
 
 	int size = strn.size( ) * sizeof( strn.front( ) );
 

--- a/EDF_Tools/util.h
+++ b/EDF_Tools/util.h
@@ -1,18 +1,18 @@
 #pragma once
 
-void Read2Bytes( unsigned char *chunk, std::vector<char> buf, int pos );
-void Read2BytesReversed( unsigned char *chunk, std::vector<char> buf, int pos );
-void Read4Bytes(unsigned char* chunk, std::vector<char> buf, int pos);
-void Read4BytesReversed(unsigned char* chunk, std::vector<char> buf, int pos);
+void Read2Bytes( unsigned char *chunk, const std::vector<char>& buf, int pos );
+void Read2BytesReversed( unsigned char *chunk, const std::vector<char>& buf, int pos );
+void Read4Bytes(unsigned char* chunk, const std::vector<char>& buf, int pos);
+void Read4BytesReversed(unsigned char* chunk, const std::vector<char>& buf, int pos);
 //Read specified number of bytes, which should be a multiple of 2
-void ReadNBytesReversed(unsigned char* chunk, std::vector<char> buf, int pos, int num);
+void ReadNBytesReversed(unsigned char* chunk, const std::vector<char>& buf, int pos, int num);
 
-std::string ReadRaw(std::vector<char> buf, int pos, int num);
+std::string ReadRaw(const std::vector<char>& buf, int pos, int num);
 //wrong reading, do not use.
-short ReadInt16(std::vector<char> buf, int pos, bool swapEndian = false);
-uint16_t ReadUInt16(std::vector<char> buf, int pos, bool swapEndian = false);
+short ReadInt16(const std::vector<char>& buf, int pos, bool swapEndian = false);
+uint16_t ReadUInt16(const std::vector<char>& buf, int pos, bool swapEndian = false);
 //Poor performance as a float and should not be used
-float ReadHalfFloat(std::vector<char> buf, int pos, bool swapEndian = false);
+float ReadHalfFloat(const std::vector<char>& buf, int pos, bool swapEndian = false);
 
 int GetIntFromChunk( unsigned char *chunk );
 // Fast read of int32 using assembly
@@ -24,8 +24,8 @@ char* IntToBytes( int i, bool flip = true );
 std::wstring ToString( int i );
 std::wstring ToString( float f );
 
-std::wstring ReadUnicode( std::vector<char> chunk, int pos, bool swapEndian = false );
-std::string ReadASCII(std::vector<char> chunk, int pos);
+std::wstring ReadUnicode( const std::vector<char>& chunk, int pos, bool swapEndian = false );
+std::string ReadASCII(const std::vector<char>& chunk, int pos);
 
 //Util fn for simple tokenisation
 std::wstring SimpleTokenise( std::wstring &input, wchar_t delim );
@@ -39,16 +39,16 @@ std::wstring KillWhitespace( std::wstring in );
 std::wstring KillSpaceAndDebug(std::wstring in);
 
 //Function to write a string to a char vector
-void PushStringToVector(std::string strn, std::vector< char >* bytes);
+void PushStringToVector(const std::string& strn, std::vector< char >* bytes);
 //Function to write a string to a char vector, but no tail
-void PushStringToVectorNoEnd(std::string strn, std::vector< char >* bytes);
+void PushStringToVectorNoEnd(const std::string& strn, std::vector< char >* bytes);
 //Function to write a wstring to a char vector
-void PushWStringToVector( std::wstring strn, std::vector< char > *bytes );
+void PushWStringToVector( const std::wstring& strn, std::vector< char > *bytes );
 
 //Checks if a string is a valid int
-bool IsValidInt( const std::wstring input );
+bool IsValidInt( const std::wstring& input );
 //Checks if a string is a valid float
-bool IsValidFloat( const std::wstring input );
+bool IsValidFloat( const std::wstring& input );
 
 //Converts a int hex to float
 float IntHexAsFloat(int in);
@@ -73,8 +73,8 @@ ValueType DetermineType( std::wstring input );
 std::wstring ReadFile( const wchar_t* filename );
 
 //Replaces all instances in a string
-void FindAndReplaceAll( std::wstring & data, std::wstring toSearch, std::wstring replaceStr );
-void FindAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr);
+void FindAndReplaceAll( std::wstring & data, const std::wstring& toSearch, const std::wstring& replaceStr );
+void FindAndReplaceAll(std::string& data, const std::string& toSearch, const std::string& replaceStr);
 
 //Convert UTF8 to wide string
 std::wstring UTF8ToWide(const std::string& source);


### PR DESCRIPTION
Massively speed up the code by reducing the number of copies due to pass by value of large objects, and by using functions that can transfer data in bulk rather than byte by byte for loop

This reduces the amount of time to extract IG_EDFROOM02.RAB, the largest archive in EDF5, from 6 minutes to 4 seconds.

There are also a couple of error fixes that were preventing clang from compiling the code.